### PR TITLE
 Fixed #42 Logo is not displaying on chat window

### DIFF
--- a/assets/assets/style.css
+++ b/assets/assets/style.css
@@ -56,10 +56,7 @@
   padding: 14px;
   color: white;
   transition: background 0.3s;
-}
-
-#chatbot_toggle:hover {
-  background: rgba(219, 226, 0, .05);
+  cursor: pointer;
 }
 
 /* Header Styles */
@@ -85,7 +82,7 @@
   margin-left: 8px;
 }
 
-.main-title svg {
+.main-title img {
   height: 24px;
 }
 

--- a/assets/index.php
+++ b/assets/index.php
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
   <!-- Chatbot header -->
   <div class="main-title">
     <div>
-      <img src="/assets/images/logo.png" alt="" />
+        <img src="<?php echo esc_url(plugin_dir_url(__FILE__) . '/images/logo-white.png'); ?>" alt="Logo" />
     </div>
     <!-- Display the assistant's name from the settings -->
     <span><?php echo esc_html(get_option('vacw_assistant_name', 'Customer Support Assistant')); ?></span>


### PR DESCRIPTION
    - logo path fixed
    - fixed - on hover chat widget background becomes transparent which may cause logo overlapping